### PR TITLE
Automatically Generate Numeric and Bitwise Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Nonetheless you may need to define your own keys, that is possible by pairing co
 $ php artisan make:enum Status 'IN_PROGRESS=1|COMPLETE=2|FAILED=3'
 ```
 
-The command above will generate the following `Progress` enum:
+The command above will generate the following `Status` enum:
 
 ``` php
 <?php
@@ -122,6 +122,85 @@ class Status extends Enum
             static::IN_PROGRESS => 'In progress',
             static::COMPLETE => 'Complete',
             static::FAILED => 'Failed',
+        ];
+    }
+}
+```
+
+You may also automatically generate numeric or bitwise keys by adding the `--numeric` or `--bitwise` option.
+
+``` bash
+$ php artisan make:enum Status 'IN_PROGRESS=1|COMPLETE=2|FAILED=3'
+$ php artisan make:enum Status 'IN_PROGRESS|COMPLETE|FAILED --numeric'
+```
+
+The above commands will both generate the following `Status` enums:
+
+``` php
+<?php
+
+namespace App\Enums;
+
+use Rexlabs\Enum\Enum;
+
+/**
+ * The Status enum.
+ *
+ * @method static self IN_PROGRESS()
+ * @method static self COMPLETE()
+ * @method static self FAILED()
+ */
+class Status extends Enum
+{
+    const IN_PROGRESS = 1;
+    const COMPLETE = 2;
+    const FAILED = 3;
+}
+```
+
+You can also specify enum values by pairing the constant names and keys with an `=` character.
+
+``` bash
+$ php artisan make:enum JSON 'HEX_TAG=Hex Tag=1|HEX_AMP=Hex Amp=2|HEX_APOS=Hex Apos=4|HEX_QUOT=Hex Quot=8'
+$ php artisan make:enum JSON 'HEX_TAG=Hex Tag|HEX_AMP=Hex Amp|HEX_APOS=Hex Apos|HEX_QUOT=Hex Quot --bitwise'
+```
+
+The above commands will both generate the following `JSON` enum and implement the `map()` method:
+
+``` php
+<?php
+
+namespace App\Enums;
+
+use Rexlabs\Enum\Enum;
+
+/**
+ * The JSON enum.
+ *
+ * @method static self HEX_TAG()
+ * @method static self HEX_AMP()
+ * @method static self HEX_APOS()
+ * @method static self HEX_QUOT()
+ */
+class JSON extends Enum
+{
+    const HEX_TAG = 1;
+    const HEX_AMP = 2;
+    const HEX_APOS = 4;
+    const HEX_QUOT = 8;
+
+    /**
+     * Retrieve a map of enum keys and values.
+     *
+     * @return array
+     */
+    public static function map() : array
+    {
+        return [
+            static::HEX_TAG => 'Hex Tag',
+            static::HEX_AMP => 'Hex Amp',
+            static::HEX_APOS => 'Hex Apos',
+            static::HEX_QUOT => 'Hex Quot',
         ];
     }
 }

--- a/src/Console/Commands/EnumMakeCommand.php
+++ b/src/Console/Commands/EnumMakeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use Cerbero\LaravelEnum\StubAssembler;
 use Cerbero\LaravelEnum\Parser;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
 
 /**
  * The Artisan command to generate Enum classes.
@@ -21,6 +22,8 @@ class EnumMakeCommand extends GeneratorCommand
     protected $signature = 'make:enum
                             {name : The name of the class}
                             {enum : The definition of the enum}
+                            {--numeric : Create a numeric enum}
+                            {--bitwise : Create a bitwise enum}
                             {--p|path= : The path to generate enums in}
                             {--f|force : Create the class even if the enum already exists}';
 
@@ -46,6 +49,21 @@ class EnumMakeCommand extends GeneratorCommand
     protected function getStub()
     {
         return __DIR__ . '/../../../stubs/enum.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     * @throws \Illuminate\Contracts\Filesystem\FileNotFoundException
+     */
+    public function handle()
+    {
+        if ($this->option('numeric') && $this->option('bitwise')) {
+            throw new InvalidArgumentException('Only one option of "numeric" or "bitwise" can be set');
+        }
+
+        return parent::handle();
     }
 
     /**
@@ -100,6 +118,6 @@ class EnumMakeCommand extends GeneratorCommand
         $enum = (array) $this->argument('enum');
         $definition = trim($enum[0]);
 
-        return (new Parser)->parseDefinition($definition);
+        return (new Parser)->parseDefinition($definition, $this->option('numeric'), $this->option('bitwise'));
     }
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -13,18 +13,28 @@ class Parser
     const SEPARATOR_ENUM = '|';
     const SEPARATOR_PART = '=';
 
+    private $key = 1;
+
     /**
      * Parse the enums definition
      *
      * @param string $definition
+     * @param bool $numeric
+     * @param bool $bitwise
      * @return array
      */
-    public function parseDefinition(string $definition) : array
+    public function parseDefinition(string $definition, bool $numeric = false, bool $bitwise = false) : array
     {
         $enums = explode(static::SEPARATOR_ENUM, $definition);
 
-        return array_map(function (string $enum) {
+        return array_map(function (string $enum) use ($numeric, $bitwise) {
             $parts = explode(static::SEPARATOR_PART, $enum);
+
+            if ($numeric) {
+                $parts = $this->addNumericKey($parts);
+            } elseif ($bitwise) {
+                $parts = $this->addBitwiseKey($parts);
+            }
 
             return $this->hydrateEnumDefinition($parts);
         }, $enums);
@@ -43,6 +53,34 @@ class Parser
             $enumDefinition->key = isset($parts[1]) ? $this->parseValue($parts[1]) : Str::lower($parts[0]);
             $enumDefinition->value = isset($parts[2]) ? $this->parseValue($parts[2]) : null;
         });
+    }
+
+    /**
+     * Add a numeric enum key to the parts.
+     *
+     * @param  array  $parts
+     * @return array
+     */
+    private function addNumericKey(array $parts)
+    {
+        array_splice($parts, 1, 0, $this->key);
+        $this->key++;
+
+        return $parts;
+    }
+
+    /**
+     * Add a bitwise enum key to the parts.
+     *
+     * @param  array  $parts
+     * @return array
+     */
+    private function addBitwiseKey(array $parts)
+    {
+        array_splice($parts, 1, 0, $this->key);
+        $this->key *= 2;
+
+        return $parts;
     }
 
     /**

--- a/tests/EnumMakeCommandTest.php
+++ b/tests/EnumMakeCommandTest.php
@@ -38,6 +38,16 @@ class EnumMakeCommandTest extends TestCase
     /**
      * @test
      */
+    public function oneKeyGenerationOption()
+    {
+        $this->expectExceptionMessage('Only one option of "numeric" or "bitwise" can be set');
+
+        $this->artisan('make:enum Test TEST --numeric --bitwise');
+    }
+
+    /**
+     * @test
+     */
     public function generateEnum()
     {
         $this->artisan('make:enum Test TEST')->assertExitCode(0);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -152,6 +152,94 @@ class ParserTest extends TestCase
     /**
      * @test
      */
+    public function parseNumericDefinition()
+    {
+        $definition = 'ONE|TWO|THREE';
+        $expectedNames = ['ONE', 'TWO', 'THREE'];
+        $expectedKeys = [1, 2, 3];
+
+        $enums = $this->parser->parseDefinition($definition, true);
+
+        $this->assertIsArray($enums);
+        $this->assertCount(3, $enums);
+
+        for ($i = 0; $i < count($enums); $i++) {
+            $this->assertInstanceOf(EnumDefinition::class, $enums[$i]);
+            $this->assertSame($expectedNames[$i], $enums[$i]->name);
+            $this->assertSame($expectedKeys[$i], $enums[$i]->key);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function parseNumericDefinitionWithValues()
+    {
+        $definition = 'ONE=Number One|TWO=Number Two|THREE=Number Three';
+        $expectedNames = ['ONE', 'TWO', 'THREE'];
+        $expectedKeys = [1, 2, 3];
+        $expectedValues = ['Number One', 'Number Two', 'Number Three'];
+
+        $enums = $this->parser->parseDefinition($definition, true);
+
+        $this->assertIsArray($enums);
+        $this->assertCount(3, $enums);
+
+        for ($i = 0; $i < count($enums); $i++) {
+            $this->assertInstanceOf(EnumDefinition::class, $enums[$i]);
+            $this->assertSame($expectedNames[$i], $enums[$i]->name);
+            $this->assertSame($expectedKeys[$i], $enums[$i]->key);
+            $this->assertSame($expectedValues[$i], $enums[$i]->value);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function parseBitwiseDefinition()
+    {
+        $definition = 'ONE|TWO|FOUR|EIGHT';
+        $expectedNames = ['ONE', 'TWO', 'FOUR', 'EIGHT'];
+        $expectedKeys = [1, 2, 4, 8];
+
+        $enums = $this->parser->parseDefinition($definition, false, true);
+
+        $this->assertIsArray($enums);
+        $this->assertCount(4, $enums);
+
+        for ($i = 0; $i < count($enums); $i++) {
+            $this->assertInstanceOf(EnumDefinition::class, $enums[$i]);
+            $this->assertSame($expectedNames[$i], $enums[$i]->name);
+            $this->assertSame($expectedKeys[$i], $enums[$i]->key);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function parseBitwiseDefinitionWithValues()
+    {
+        $definition = 'ONE=0b0001|TWO=0b0010|FOUR=0b0100|EIGHT=0b1000';
+        $expectedNames = ['ONE', 'TWO', 'FOUR', 'EIGHT'];
+        $expectedKeys = [1, 2, 4, 8];
+        $expectedValues = ['0b0001', '0b0010', '0b0100', '0b1000'];
+
+        $enums = $this->parser->parseDefinition($definition, false, true);
+
+        $this->assertIsArray($enums);
+        $this->assertCount(4, $enums);
+
+        for ($i = 0; $i < count($enums); $i++) {
+            $this->assertInstanceOf(EnumDefinition::class, $enums[$i]);
+            $this->assertSame($expectedNames[$i], $enums[$i]->name);
+            $this->assertSame($expectedKeys[$i], $enums[$i]->key);
+            $this->assertSame($expectedValues[$i], $enums[$i]->value);
+        }
+    }
+
+    /**
+     * @test
+     */
     public function parseNullables()
     {
         $actual1 = $this->parser->parseValue(null);


### PR DESCRIPTION
## Description

Adds a `--numeric` and `--bitwise` options to the command, to allow the user to automatically generate numeric and bitwise keys for the enum class.

From the Updated README:

You may also automatically generate numeric or bitwise keys by adding the `--numeric` or `--bitwise` option.

``` bash
$ php artisan make:enum Status 'IN_PROGRESS=1|COMPLETE=2|FAILED=3'
$ php artisan make:enum Status 'IN_PROGRESS|COMPLETE|FAILED --numeric'
```

The above commands will both generate the following `Status` enums:

``` php
<?php

namespace App\Enums;

use Rexlabs\Enum\Enum;

/**
 * The Status enum.
 *
 * @method static self IN_PROGRESS()
 * @method static self COMPLETE()
 * @method static self FAILED()
 */
class Status extends Enum
{
    const IN_PROGRESS = 1;
    const COMPLETE = 2;
    const FAILED = 3;
}
```

You can also specify enum values by pairing the constant names and keys with an `=` character.

``` bash
$ php artisan make:enum JSON 'HEX_TAG=Hex Tag=1|HEX_AMP=Hex Amp=2|HEX_APOS=Hex Apos=4|HEX_QUOT=Hex Quot=8'
$ php artisan make:enum JSON 'HEX_TAG=Hex Tag|HEX_AMP=Hex Amp|HEX_APOS=Hex Apos|HEX_QUOT=Hex Quot --bitwise'
```

The above commands will both generate the following `JSON` enum and implement the `map()` method:

``` php
<?php

namespace App\Enums;

use Rexlabs\Enum\Enum;

/**
 * The JSON enum.
 *
 * @method static self HEX_TAG()
 * @method static self HEX_AMP()
 * @method static self HEX_APOS()
 * @method static self HEX_QUOT()
 */
class JSON extends Enum
{
    const HEX_TAG = 1;
    const HEX_AMP = 2;
    const HEX_APOS = 4;
    const HEX_QUOT = 8;

    /**
     * Retrieve a map of enum keys and values.
     *
     * @return array
     */
    public static function map() : array
    {
        return [
            static::HEX_TAG => 'Hex Tag',
            static::HEX_AMP => 'Hex Amp',
            static::HEX_APOS => 'Hex Apos',
            static::HEX_QUOT => 'Hex Quot',
        ];
    }
}
```

## Motivation and context

Saves the user some typing and, in the case of bitwise enums thinking, when generating an enum class. Especially useful when a class has a lot of enum keys.

## How has this been tested?

Added 4 tests to check if the parser handles automatic numeric keys, numeric keys with values, bitwise keys, and bitwise keys with values correctly. Ran `phpunit` to see if the tests passed.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [ ] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
