### PR TITLE
Create HasEnum.php

### DIFF
--- a/src/Traits/HasEnum.php
+++ b/src/Traits/HasEnum.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Rexlabs\Enum\Traits;
+
+use Rexlabs\Enum\Enum;
+use Rexlabs\Enum\Exceptions\InvalidKeyException;
+
+trait HasEnum
+{
+    public function getAttribute($key)
+    {
+        $value = parent::getAttribute($key);
+
+        if ($this->hasEnumDecodeKey($key)) {
+            $value = $this->decodeEnum($key, $value);
+        }
+
+        return $value;
+    }
+
+    public function setAttribute($key, $value)
+    {
+        if ($value !== null && $this->hasEnumDecodeKey($key)) {
+            if ($this->hasCast($key)) {
+                $value = $this->castAttribute($key, $value);
+            }
+
+            $encoding = $this->getEnumEncoding($key);
+            
+            if ($value instanceof $encoding['class']) {
+                $value = $value->key();
+            } elseif (gettype($encoding['class']::keys()[0]) != gettype($value)) {
+                $value = $encoding['class']::keyForValue($value);
+            }
+
+            if ($encoding['column'] != $key) {
+                $this->setAttribute($encoding['column'], $value);
+            } else {
+                $this->attributes[$key] = $value;
+            }
+
+            return $this;
+        }
+
+        return parent::setAttribute($key, $value);
+    }
+
+    /**
+     * Determine whether an attribute should be decode to an enum value.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function hasEnumDecodeKey($key): bool
+    {
+        return array_key_exists($key, $this->getEnumEncodings());
+    }
+
+    protected function decodeEnum(string $key, $value)
+    {
+        $encoding = $this->getEnumEncoding($key);
+
+        $enumClass = $encoding['class'];
+        $value = $encoding['column'] == $key ? $value : $this->getAttribute($encoding['column']);
+
+        try {
+            return $enumClass::valueForKey($value);
+        } catch (InvalidKeyException $ex) {
+            return $value;
+        }
+    }
+
+    protected function getEnumEncodings()
+    {
+        return property_exists($this, 'decodeEnums') ? $this->decodeEnums : [];
+    }
+
+    protected function getEnumEncoding(string $key)
+    {
+        $encoding = $this->getEnumEncodings()[$key];
+
+        $class = is_string($encoding)
+            ? $encoding : $encoding[1];
+        $column = is_string($encoding)
+            ? $key : $encoding[0];
+
+        if (! is_subclass_of($class, Enum::class)) {
+            throw new \ErrorException("{$class} is not Enum");
+        }
+
+        return compact('class', 'column');
+    }
+}


### PR DESCRIPTION
# Create Enum decoder for Model's attribute

## Description

Add a `Trait` for usage in `Model` class, so we just need use the trait inside intended Model and add the `decodeEnums` property into the class.
the getter always return Enum's value.
the setter always save Enum's key to database.

### example: 
say we have Enum class with map 
```php
UserRole::map(); // [1 => 'admin', 2 => 'manager', 3 => 'staff', 4 => 'guest']
UserLevel::map(); // [1 => 'newbie', 2 => 'novice', 3 => 'warrior']
```
add into Model
```php
use Rexlabs\Enum\Traits\HasEnum;

class User extends Model
{
    use HasEnum;

    protected $decodeEnums = [
       //  'attribute' => Enum::class,
        'role' => UserRole::class,
        // or 'custom_attribute' => ['attribute_column', Enum::class],
        // ex: 'level' => ['level_id', UserLevel::class]
    ];
}
```
```php
echo $user->role; // 'admin'

$user->role = 'manager'; 
echo $user->role; // 'manager'

$user->role = UserRole::ADMIN;
echo $user->role; // 'admin'

$user->role = UserRole::STAFF();
echo $user->role; // 'staff'

$user->role = 2;
echo $user->role; // 'manager'

echo $user->level; // 'newbie'
echo $user->level_id; // 1

$user->level = 'novice'
echo $user->level_id; // 2

```

## Motivation and context

easy set and get model's attribute with Enum's key or value,
